### PR TITLE
Check if constants are already defined.

### DIFF
--- a/libraries/auto_patch.rb
+++ b/libraries/auto_patch.rb
@@ -24,8 +24,8 @@ class Chef
   class Recipe
     # Chef::Recipe::AutoPatch class
     class AutoPatch
-      WEEKS = %w(first second third fourth)
-      WEEKDAYS = %w(sunday monday tuesday wednesday thursday friday saturday)
+      WEEKS = %w(first second third fourth) unless defined?(WEEKS)
+      WEEKDAYS = %w(sunday monday tuesday wednesday thursday friday saturday) unless defined?(WEEKDAYS)
 
       def self.monthly_date(year, month, monthly_specifier)
         Date.new(year, month, monthly_day(year, month, monthly_specifier))


### PR DESCRIPTION
Hello! This adds a check for constants that might already be defined in auto-patch, before defining them. I was seeing the following lines over and over in my chefspec tests:

```
/tmp/d20150506-30326-ogpsp4/cookbooks/auto-patch/libraries/auto_patch.rb:21: warning: already initialized constant Chef::Recipe::AutoPatch::WEEKS
/tmp/d20150506-30326-ogpsp4/cookbooks/auto-patch/libraries/auto_patch.rb:21: warning: previous definition of WEEKS was here
/tmp/d20150506-30326-ogpsp4/cookbooks/auto-patch/libraries/auto_patch.rb:22: warning: already initialized constant Chef::Recipe::AutoPatch::WEEKDAYS
/tmp/d20150506-30326-ogpsp4/cookbooks/auto-patch/libraries/auto_patch.rb:22: warning: previous definition of WEEKDAYS was here
```

This squelches the errors, for rspec + chefspec, and any other application that might reload `libraries/auto_patch.rb`.
